### PR TITLE
Async observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are three key objects: [Subject](https://github.com/bunch-of-friends/obser
 A function, which gets called on a change.
 ```ts
 export interface Observer<T> {
-    (newState: T, previousState?: T): void;
+    (newState: T, previousState?: T): void | Promise<void>;
 }
 ```
 
@@ -26,7 +26,7 @@ export interface Subject<T> {
     unregisterObserver(observer: Observer<T>): void;
     unregisterObserversOfOwner(owner: Object): void;
     unregisterAllObservers(): void;
-    notifyObservers(newState?: T): void;
+    notifyObservers(newState?: T): Promise<void>;
     getCurrentState(): T;
 }
 ```
@@ -37,7 +37,8 @@ Observable is a subset of Subject and is intended to be exposed outside of the o
 export interface Observable<T> {
     register: (observer: Observer<T>) => Observer<T>;
     unregister: (observer: Observer<T>) => void;
-    unregisterAll: () => void;
+    unregisterAllObservers: () => void;
+    getCurrentState(): T;
 }
 ```
 
@@ -104,7 +105,7 @@ class Component {
     public onStateChanged = createObservable(stateSubject);
 
     // shorthand if you only want to subscribe to the state chaning to Stopped
-    public onLoaded = createObservableForValue(stateSubject, State.Stopped);
+    public onLoaded = createObservableForValue(stateSubject, State.Loaded);
 
     constructor() {
         // notifyChanges would usually be called by some more reasonable code
@@ -124,6 +125,10 @@ class ComponentConsumer {
     }
 }
 ```
+
+## Async observers
+
+The `Observer` function can return a promise. When `Subject` is notified of changes by calling `notifyObservers`, it will wait for all observers that did return a promise and it will resolve, when all observers resolve or reject. `notifyObservers` will never reject, it will always resolve. Errors are expected to be handled by the observers.
 
 ## Classes vs closures
 Why are the `Subject` and `Observable` not ES6 classes?

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class Component {
     // use this to subscribe to any state change
     public onStateChanged = createObservable(stateSubject);
 
-    // shorthand if you only want to subscribe to the state chaning to Stopped
+    // shorthand if you only want to subscribe to the state changing to Loaded
     public onLoaded = createObservableForValue(stateSubject, State.Loaded);
 
     constructor() {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple implementation of the [observer pattern](https://en.wikipedia.org/wiki/
 There are three key objects: [Subject](https://github.com/bunch-of-friends/observable/blob/master/src/subject.ts), [Observable](https://github.com/bunch-of-friends/observable/blob/master/src/observable.ts) and [Observer](https://github.com/bunch-of-friends/observable/blob/master/src/observer.ts).
 
 ### Observer
-A function, which gets called on a change.
+A function, which gets called on a change. Observers can return a promise, see [Async observers](#async-observers) below.
 ```ts
 export interface Observer<T> {
     (newState: T, previousState?: T): void | Promise<void>;

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ class ComponentConsumer {
 ```
 
 ## Async observers
-The `Observer` function can return a promise. When `Subject` is notified of changes by calling `notifyObservers`, it will wait for all observers that did return a promise and it will resolve, when all observers resolve or reject. `notifyObservers` will never reject, it will always resolve. Errors are expected to be handled by the observers.
+The `Observer` function can return a promise. When `Subject` is notified of changes by the `notifyObservers` function, it will wait for all observers that return a promise and it will resolve, when all observers resolve or reject. `notifyObservers` will never reject, it catches all rejections. Errors are expected to be handled by the observers.
 
 ## Classes vs closures
 Why are the `Subject` and `Observable` not ES6 classes?

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ class ComponentConsumer {
 ```
 
 ## Async observers
-
 The `Observer` function can return a promise. When `Subject` is notified of changes by calling `notifyObservers`, it will wait for all observers that did return a promise and it will resolve, when all observers resolve or reject. `notifyObservers` will never reject, it will always resolve. Errors are expected to be handled by the observers.
 
 ## Classes vs closures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunch-of-friends/observable",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A simple implementation of the observer pattern written in TypeScript, usable in JavaScript as well.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunch-of-friends/observable",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "A simple implementation of the observer pattern written in TypeScript, usable in JavaScript as well.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,5 +1,5 @@
 import { Observer } from './observer';
-import { Subject, createSubject } from './subject';
+import { Subject } from './subject';
 
 export interface Observable<T> {
     getCurrentState: () => T;

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,18 +1,20 @@
 import { Observer } from './observer';
-import { Subject } from './subject';
+import { Subject, createSubject } from './subject';
 
 export interface Observable<T> {
+    getCurrentState: () => T;
     register: (observer: Observer<T>) => Observer<T>;
     unregister: (observer: Observer<T>) => void;
-    unregisterAll: () => void;
+    unregisterAllObservers: () => void;
 }
 
 export function createObservable<T>(subject: Subject<T>): Observable<T> {
     const observerOwner = {};
     return {
+        getCurrentState: () => subject.getCurrentState(),
         register: (observer: Observer<T>) => subject.registerObserver(observer, observerOwner),
         unregister: (observer: Observer<T>) => subject.unregisterObserver(observer),
-        unregisterAll: () => subject.unregisterObserversOfOwner(observerOwner)
+        unregisterAllObservers: () => subject.unregisterObserversOfOwner(observerOwner)
     };
 }
 
@@ -29,6 +31,7 @@ export function createObservableForValue<T>(subject: Subject<T>, value: T): Obse
     }
 
     return {
+        getCurrentState: () => undefined,
         register: (exactValueObserver: Observer<void>) => {
             const registeredObserver = registerExactValueObserver(exactValueObserver);
             registeredObserversMap.push({ registeredObserver, exactValueObserver });
@@ -40,6 +43,6 @@ export function createObservableForValue<T>(subject: Subject<T>, value: T): Obse
                 registeredObservers.forEach(x => subject.unregisterObserver(x.registeredObserver));
             }
         },
-        unregisterAll: () => subject.unregisterObserversOfOwner(observerOwner)
+        unregisterAllObservers: () => subject.unregisterObserversOfOwner(observerOwner)
     };
 }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,3 +1,3 @@
 export interface Observer<T> {
-    (newState: T, previousState?: T): void;
+    (newState: T, previousState?: T): void | Promise<void>;
 }

--- a/tests/observable.test.ts
+++ b/tests/observable.test.ts
@@ -45,7 +45,7 @@ describe('Observable', () => {
         observer1.mockReset();
         observer2.mockReset();
 
-        observable.unregisterAll();
+        observable.unregisterAllObservers();
         subject.notifyObservers('test2');
 
         expect(observer1).not.toBeCalled();
@@ -101,7 +101,7 @@ describe('ObservableForValue', () => {
         observable.register(observer1);
         observable.register(observer2);
 
-        observable.unregisterAll();
+        observable.unregisterAllObservers();
 
         subject.notifyObservers({});
 
@@ -151,12 +151,37 @@ describe('Multiple observables', () => {
         observable1.register(observer1);
         observable2.register(observer2);
 
-        observable1.unregisterAll();
+        observable1.unregisterAllObservers();
 
         subject.notifyObservers(123);
 
         expect(observer1).not.toHaveBeenCalled();
         expect(observer2).toHaveBeenCalled();
+    });
+});
+
+describe('getCurrentState', () => {
+    it('should return subjects current state', () => {
+        const subject = createSubject();
+        const observable = createObservable(subject);
+
+        const subjectGetCurrentStateMock = subject.getCurrentState = jest.fn();
+
+        observable.getCurrentState();
+
+        expect(subjectGetCurrentStateMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return undefined for value observables', () => {
+        const subject = createSubject();
+        const observable = createObservableForValue(subject, 1);
+
+        const subjectGetCurrentStateMock = subject.getCurrentState = jest.fn();
+
+        const currentState = observable.getCurrentState();
+
+        expect(subjectGetCurrentStateMock).not.toHaveBeenCalled();
+        expect(currentState).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
The `Observer` function can return a promise. When `Subject` is notified of changes by calling `notifyObservers`, it will wait for all observers that did return a promise and it will resolve, when all observers resolve or reject. `notifyObservers` will never reject, it will always resolve. Errors are expected to be handled by the observers.

Also removed `shouldNotifyOnlyIfNewStateDiffers` from options to keep things simple.