### PR TITLE
Fixes a short circuiting bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunch-of-friends/observable",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A simple implementation of the observer pattern written in TypeScript, usable in JavaScript as well.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,6 +9,10 @@
     {
       "name": "David Bohunek",
       "email": "bohunek@gmail.com"
+    },
+    {
+      "name": "Nick Michael",
+      "email": "nickmichael@live.co.uk"
     }
   ],
   "keywords": [

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -9,6 +9,10 @@ export interface Subject<T> {
   getCurrentState(): T;
 }
 
+function reflect(promise: Promise<any>): Promise<any> {
+  return promise.then(res => res).catch(e => e);
+}
+
 export function createSubject<T>(options?: { initialState?: T }): Subject<T> {
   let currentState =
     !options || options.initialState === undefined
@@ -60,9 +64,7 @@ export function createSubject<T>(options?: { initialState?: T }): Subject<T> {
         }
       });
 
-      return Promise.all(promises)
-        .then(() => Promise.resolve())
-        .catch(() => Promise.resolve());
+      return Promise.all(promises.map(reflect)).then(() => Promise.resolve());
     },
     getCurrentState: () => {
       return currentState;

--- a/tests/subject.spec.ts
+++ b/tests/subject.spec.ts
@@ -130,6 +130,31 @@ describe("Subject", () => {
         expect(true).toBeTruthy(); // here just have an expectation in the test
       });
     });
+
+    it("should not short circuit if one of the observers returns a rejected promise", () => {
+      let called = false;
+
+      subject.registerObserver(
+        jest.fn().mockReturnValue(Promise.reject("")),
+        callbacksOwner
+      );
+
+      subject.registerObserver(
+        jest.fn().mockReturnValue(
+          new Promise(resolve => {
+            setTimeout(() => {
+              called = true;
+              resolve();
+            }, 1);
+          })
+        ),
+        callbacksOwner
+      );
+
+      return subject.notifyObservers().then(() => {
+        expect(called).toBeTruthy();
+      });
+    });
   });
 
   describe("unregisterObserver", () => {


### PR DESCRIPTION
If an observer returns a rejected promise, `Promise.all` will short circuit and return before the remaining observers have resolved.

Hopefully we can eventually swap this out for `Promise.allSettled` ([see here](https://github.com/tc39/proposal-promise-allSettled)) but for now we have to map over each promise and catch errors.