### PR TITLE
Fix some unregister issues

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -25,7 +25,7 @@ export function createObservableForValue<T>(
   value: T
 ): Observable<void> {
   const observerOwner = {};
-  const registeredObserversMap = new Array<{
+  let registeredObserversMap = new Array<{
     registeredObserver: Observer<T>;
     exactValueObserver: Observer<void>;
   }>();
@@ -46,14 +46,15 @@ export function createObservableForValue<T>(
       return exactValueObserver;
     },
     unregister: (exactValueObserver: Observer<void>) => {
-      const registeredObservers = registeredObserversMap.filter(
-        x => x.exactValueObserver === exactValueObserver
+      registeredObserversMap = registeredObserversMap.filter(
+        (x) => {
+          if (x.exactValueObserver === exactValueObserver) {
+            subject.unregisterObserver(x.registeredObserver);
+            return false;
+          }
+          return true;
+        }
       );
-      if (registeredObservers) {
-        registeredObservers.forEach(x =>
-          subject.unregisterObserver(x.registeredObserver)
-        );
-      }
     },
     unregisterAllObservers: () =>
       subject.unregisterObserversOfOwner(observerOwner)

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -28,13 +28,9 @@ export function createSubject<T>(options?: { initialState?: T }): Subject<T> {
       return observer;
     },
     unregisterObserver: (observer: Observer<T>) => {
-      registeredObservers.forEach((item, index) => {
-        if (item.observer !== observer) {
-          return;
-        }
-
-        registeredObservers.splice(index, 1);
-      });
+      registeredObservers = registeredObservers.filter(
+        item => item.observer !== observer
+      );
     },
     unregisterObserversOfOwner: (owner: Object) => {
       registeredObservers = registeredObservers.filter(


### PR DESCRIPTION
Some fixes:
- The unregisterObserver method on subject can have issues if multiple copies of the same observer are added (basically splicing an array during a forEach loop has issues).
- The unregister method on observable doesn't cleanup the internal registeredObserversMap.
